### PR TITLE
Minor tweak to metro/metro

### DIFF
--- a/metro
+++ b/metro
@@ -160,9 +160,7 @@ class Metro:
                     print key+": "+str(settings[key])
 
     def setup_paths(self):
-        binpath = os.path.abspath(sys.argv[0])
-        if os.path.islink(binpath):
-            binpath = os.readlink(binpath)
+        binpath = os.path.realpath(sys.argv[0])
 
         libdir = os.path.dirname(binpath)
         if self.has_opts(["-l", "--libdir"]):


### PR DESCRIPTION
This fixes a bug I ran into when I first deployed metro where it couldn't find libdir, plus it's simpler.  Uses os.path.realpath() rather than a combination of abspath() and readlink()
